### PR TITLE
useEvents path

### DIFF
--- a/webview/TuningShop.vue
+++ b/webview/TuningShop.vue
@@ -1,5 +1,5 @@
 <script lang="ts" setup>
-import { useEvents } from '../../../../webview/composables/useEvents';
+import { useEvents } from '@Composables/useEvents';
 import { ref, toRaw } from 'vue';
 import { tuningShopEvents } from '../shared/events';
 


### PR DESCRIPTION
changed the import for useEvents to not use a absolute path. Now you can put it in folders without a problem.